### PR TITLE
code refactor: theme updates

### DIFF
--- a/packages/cupertino_plus/.gitignore
+++ b/packages/cupertino_plus/.gitignore
@@ -37,3 +37,6 @@ app.*.symbols
 
 # Obfuscation related
 app.*.map.json
+
+coverage
+coverage_report

--- a/packages/cupertino_plus/lib/src/icons/icons.dart
+++ b/packages/cupertino_plus/lib/src/icons/icons.dart
@@ -9,8 +9,6 @@ import 'package:flutter/widgets.dart';
 ///
 /// Source: https://www.figma.com/community/file/886999666531731323
 class CupertinoPlusIcons {
-  CupertinoPlusIcons._();
-
   // TODO(jeroen-meijer): Add documentation for each icon (with a picture).
   // ignore_for_file: public_member_api_docs
 

--- a/packages/cupertino_plus/lib/src/theme/colors.dart
+++ b/packages/cupertino_plus/lib/src/theme/colors.dart
@@ -116,14 +116,6 @@ class CupertinoPlusColors extends Equatable {
     return CupertinoPlusTheme.of(context).colors;
   }
 
-  /// Looks up the nearest [CupertinoPlusTheme] in the given [BuildContext] and
-  /// returns its colors.
-  ///
-  /// If no [CupertinoPlusTheme] can be found, this returns `null`.
-  static CupertinoPlusColors? maybeOf(BuildContext context) {
-    return CupertinoPlusTheme.maybeOf(context)?.colors;
-  }
-
   /// Creates a copy of this theme with the given fields replaced with the new
   /// values.
   CupertinoPlusColors copyWith({

--- a/packages/cupertino_plus/lib/src/theme/theme.dart
+++ b/packages/cupertino_plus/lib/src/theme/theme.dart
@@ -4,81 +4,39 @@ import 'package:flutter/material.dart';
 export 'colors.dart';
 export 'theme_data.dart';
 
-// TODO(jeroen-meijer): Add documentation.
-
 /// {@template cupertino_plus_theme}
-/// A widget that provides theme data used by Cupertino Plus widgets.
-///
+/// Applies a [CupertinoPlusThemeData] to descendant Cupertino Plus widgets.
 /// {@endtemplate}
 class CupertinoPlusTheme extends InheritedWidget {
   /// {@macro cupertino_plus_theme}
   const CupertinoPlusTheme({
     Key? key,
-    this.lightTheme = const CupertinoPlusThemeData.light(),
-    this.darkTheme = const CupertinoPlusThemeData.dark(),
+    required this.data,
     required Widget child,
-  }) : super(
-          key: key,
-          child: child,
-        );
+  }) : super(key: key, child: child);
 
-  /// The light theme.
-  ///
-  /// This theme is automatically applied if the [ThemeData.brightness] of the
-  /// [Theme] that is closest in the current scope to the widget using this
-  /// theme is [Brightness.light].
-  final CupertinoPlusThemeData lightTheme;
+  /// The `CupertinoThemeData` styling for this theme.
+  final CupertinoPlusThemeData data;
 
-  /// The dark theme.
+  /// Retrieves the [CupertinoPlusThemeData] from the closest ancestor
+  /// [CupertinoPlusTheme] widget.
   ///
-  /// This theme is automatically applied if the [ThemeData.brightness] of the
-  /// [Theme] that is closest in the current scope to the widget using this
-  /// theme is [Brightness.dark].
-  final CupertinoPlusThemeData darkTheme;
-
-  /// Looks up the nearest [CupertinoPlusThemeData] in the given [BuildContext].
-  /// Whether the [lightTheme] or [darkTheme] is returned is determined by the
-  /// [ThemeData.brightness] of the [Theme] that is closest to the given
-  /// [BuildContext].
-  ///
-  /// If no [CupertinoPlusThemeData] can be found, this throws a [FlutterError].
+  /// Usage:
+  /// ```dart
+  /// final theme = CupertinoPlusTheme.of(context);
+  /// ```
   static CupertinoPlusThemeData of(BuildContext context) {
-    final data = maybeOf(context);
-
-    if (data == null) {
-      throw FlutterError(
-        'CupertinoTheme called with a context '
-        'that does not contain a CupertinoTheme.',
-      );
-    }
-
-    return data;
-  }
-
-  /// Looks up the nearest [CupertinoPlusThemeData] in the given [BuildContext].
-  /// Whether the [lightTheme] or [darkTheme] is returned is determined by the
-  /// [ThemeData.brightness] of the [Theme] that is closest to the given
-  /// [BuildContext].
-  ///
-  /// If no [CupertinoPlusThemeData] can be found, this returns `null`.
-  static CupertinoPlusThemeData? maybeOf(BuildContext context) {
-    final cupertinoPlusTheme =
+    final theme =
         context.dependOnInheritedWidgetOfExactType<CupertinoPlusTheme>();
-    final theme = Theme.of(context);
 
-    return theme.brightness == Brightness.light
-        ? cupertinoPlusTheme?.lightTheme
-        : cupertinoPlusTheme?.darkTheme;
+    assert(
+      theme != null,
+      '''You must have a CupertinoPlusTheme widget at the top of your widget tree''',
+    );
+
+    return theme!.data;
   }
 
   @override
-  bool updateShouldNotify(covariant CupertinoPlusTheme oldWidget) {
-    if (oldWidget.lightTheme != lightTheme) {
-      return true;
-    } else if (oldWidget.darkTheme != darkTheme) {
-      return true;
-    } else {
-      return false;
-    }
-  }
+  bool updateShouldNotify(CupertinoPlusTheme old) => data != old.data;
 }

--- a/packages/cupertino_plus/lib/src/theme/theme_data.dart
+++ b/packages/cupertino_plus/lib/src/theme/theme_data.dart
@@ -1,28 +1,66 @@
-import 'package:cupertino_plus/cupertino_plus.dart';
+import 'dart:ui';
 
-// TODO(jeroen-meijer): Add documentation.
+import 'package:cupertino_plus/cupertino_plus.dart';
+import 'package:flutter/foundation.dart';
+
+// ignore_for_file: cascade_invocations
 
 /// {@template cupertino_plus_theme_data}
-/// A theme data class used by Cupertino Plus widgets.
-///
+/// Defines the configuration of the overall visual `StreamFeedTheme` for a
+/// particular widget subtree.
 /// {@endtemplate}
-class CupertinoPlusThemeData {
+class CupertinoPlusThemeData with Diagnosticable {
   /// {@macro cupertino_plus_theme_data}
-  const CupertinoPlusThemeData({
-    required this.colors,
-    // TODO(jeroen-meijer): Add other properties here.
-  });
+  ///
+  /// Builds a `StreamFeedThemeData` with default values, if none are given.
+  factory CupertinoPlusThemeData({
+    CupertinoPlusColors? colors,
+    Brightness? brightness,
+  }) {
+    // Use `Brightness.light` as default if none is given
+    brightness ??= Brightness.light;
+    final _isDark = brightness == Brightness.dark;
+
+    // Use `CupertinoPlusColors.dark()` or` CupertinoPlusColors.light()`
+    // as default, depending on the value of `brightness`.
+    colors ??= _isDark
+        ? const CupertinoPlusColors.dark()
+        : const CupertinoPlusColors.light();
+
+    return CupertinoPlusThemeData.raw(
+      colors: colors,
+      brightness: brightness,
+    );
+  }
 
   /// The default theme for light-themed Cupertino Plus widgets.
-  const CupertinoPlusThemeData.light({
-    this.colors = const CupertinoPlusColors.light(),
-  });
+  factory CupertinoPlusThemeData.light() => CupertinoPlusThemeData(
+    colors: const CupertinoPlusColors.light(),
+    brightness: Brightness.light,
+  );
 
   /// The default theme for dark-themed Cupertino Plus widgets.
-  const CupertinoPlusThemeData.dark({
-    this.colors = const CupertinoPlusColors.dark(),
+  factory CupertinoPlusThemeData.dark() => CupertinoPlusThemeData(
+    colors: const CupertinoPlusColors.dark(),
+    brightness: Brightness.dark,
+  );
+
+  /// Raw `CupertinoPlusThemeData` initialization.
+  const CupertinoPlusThemeData.raw({
+    required this.colors,
+    required this.brightness,
   });
 
-  /// The colors used to style the Cupertino Plus widgets.
+  /// The colors used to style descendant Cupertino Plus widgets.
   final CupertinoPlusColors colors;
+
+  /// The `brightness` of this theme.
+  final Brightness brightness;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<CupertinoPlusColors>('colors', colors));
+    properties.add(EnumProperty<Brightness>('brightness', brightness));
+  }
 }

--- a/packages/cupertino_plus/lib/src/theme/theme_data.dart
+++ b/packages/cupertino_plus/lib/src/theme/theme_data.dart
@@ -12,7 +12,7 @@ import 'package:flutter/foundation.dart';
 class CupertinoPlusThemeData with Diagnosticable {
   /// {@macro cupertino_plus_theme_data}
   ///
-  /// Builds a `StreamFeedThemeData` with default values, if none are given.
+  /// Builds a `CupertinoPlusThemeData` with default values, if none are given.
   factory CupertinoPlusThemeData({
     CupertinoPlusColors? colors,
     Brightness? brightness,

--- a/packages/cupertino_plus/lib/src/theme/theme_data.dart
+++ b/packages/cupertino_plus/lib/src/theme/theme_data.dart
@@ -19,11 +19,11 @@ class CupertinoPlusThemeData with Diagnosticable {
   }) {
     // Use `Brightness.light` as default if none is given
     brightness ??= Brightness.light;
-    final _isDark = brightness == Brightness.dark;
+    final isDark = brightness == Brightness.dark;
 
     // Use `CupertinoPlusColors.dark()` or` CupertinoPlusColors.light()`
     // as default, depending on the value of `brightness`.
-    colors ??= _isDark
+    colors ??= isDark
         ? const CupertinoPlusColors.dark()
         : const CupertinoPlusColors.light();
 

--- a/packages/cupertino_plus/test/theme/colors_theme_test.dart
+++ b/packages/cupertino_plus/test/theme/colors_theme_test.dart
@@ -1,0 +1,72 @@
+import 'package:cupertino_plus/cupertino_plus.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('CupertinoPlusColors.light() copyWith, ==, hashCode basics', () {
+    expect(const CupertinoPlusColors.light(),
+        const CupertinoPlusColors.light().copyWith());
+    expect(const CupertinoPlusColors.light().hashCode,
+        const CupertinoPlusColors.light().copyWith().hashCode);
+  });
+
+  test('CupertinoPlusColors.dark() copyWith, ==, hashCode basics', () {
+    expect(const CupertinoPlusColors.dark(),
+        const CupertinoPlusColors.dark().copyWith());
+    expect(const CupertinoPlusColors.dark().hashCode,
+        const CupertinoPlusColors.dark().copyWith().hashCode);
+  });
+
+  testWidgets('Default theme values', (tester) async {
+    late BuildContext capturedContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (context, child) {
+          return CupertinoPlusTheme(
+            data: CupertinoPlusThemeData.light(),
+            child: child!,
+          );
+        },
+        home: Builder(
+          builder: (context) {
+            capturedContext = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    final colors = CupertinoPlusColors.of(capturedContext);
+    expect(colors.brightness, Brightness.light);
+    expect(colors.systemBlue, CupertinoPlusThemeData.light().colors.systemBlue);
+    expect(
+        colors.systemBrown, CupertinoPlusThemeData.light().colors.systemBrown);
+    expect(colors.systemCyan, CupertinoPlusThemeData.light().colors.systemCyan);
+    expect(colors.systemGray, CupertinoPlusThemeData.light().colors.systemGray);
+    expect(
+        colors.systemGray2, CupertinoPlusThemeData.light().colors.systemGray2);
+    expect(
+        colors.systemGray3, CupertinoPlusThemeData.light().colors.systemGray3);
+    expect(
+        colors.systemGray4, CupertinoPlusThemeData.light().colors.systemGray4);
+    expect(
+        colors.systemGray5, CupertinoPlusThemeData.light().colors.systemGray5);
+    expect(
+        colors.systemGray6, CupertinoPlusThemeData.light().colors.systemGray6);
+    expect(
+        colors.systemGreen, CupertinoPlusThemeData.light().colors.systemGreen);
+    expect(colors.systemIndigo,
+        CupertinoPlusThemeData.light().colors.systemIndigo);
+    expect(colors.systemMint, CupertinoPlusThemeData.light().colors.systemMint);
+    expect(colors.systemOrange,
+        CupertinoPlusThemeData.light().colors.systemOrange);
+    expect(colors.systemPink, CupertinoPlusThemeData.light().colors.systemPink);
+    expect(colors.systemPurple,
+        CupertinoPlusThemeData.light().colors.systemPurple);
+    expect(colors.systemRed, CupertinoPlusThemeData.light().colors.systemRed);
+    expect(colors.systemTeal, CupertinoPlusThemeData.light().colors.systemTeal);
+    expect(colors.systemYellow,
+        CupertinoPlusThemeData.light().colors.systemYellow);
+  });
+}

--- a/packages/cupertino_plus/test/theme/cupertino_plus_theme_data_test.dart
+++ b/packages/cupertino_plus/test/theme/cupertino_plus_theme_data_test.dart
@@ -1,0 +1,53 @@
+import 'package:cupertino_plus/cupertino_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CupertinoPlusThemeData tests', () {
+    testWidgets('Default light theme has Brightness.light', (tester) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (context, child) {
+            return CupertinoPlusTheme(
+              data: CupertinoPlusThemeData.light(),
+              child: child!,
+            );
+          },
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final theme = CupertinoPlusTheme.of(capturedContext);
+      expect(theme.brightness, Brightness.light);
+    });
+
+    testWidgets('Default dark theme has Brightness.dark', (tester) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (context, child) {
+            return CupertinoPlusTheme(
+              data: CupertinoPlusThemeData.dark(),
+              child: child!,
+            );
+          },
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final theme = CupertinoPlusTheme.of(capturedContext);
+      expect(theme.brightness, Brightness.dark);
+    });
+  });
+}

--- a/packages/cupertino_plus/test/theme/cupertino_plus_theme_data_test.dart
+++ b/packages/cupertino_plus/test/theme/cupertino_plus_theme_data_test.dart
@@ -1,4 +1,5 @@
 import 'package:cupertino_plus/cupertino_plus.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -48,6 +49,28 @@ void main() {
 
       final theme = CupertinoPlusTheme.of(capturedContext);
       expect(theme.brightness, Brightness.dark);
+    });
+
+    testWidgets('default CupertinoPlusThemeData debugFillProperties',
+        (tester) async {
+      final builder = DiagnosticPropertiesBuilder();
+      const CupertinoPlusThemeData.raw(
+        colors: CupertinoPlusColors.light(),
+        brightness: Brightness.light,
+      ).debugFillProperties(builder);
+
+      final description = builder.properties
+          .where((node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((node) => node.toString())
+          .toList();
+
+      expect(
+        description,
+        <String>[
+          '''colors: CupertinoPlusColors(Brightness.light, Color(0xffff3b30), Color(0xffff9500), Color(0xffffcc00), Color(0xff34c759), Color(0xff00c7be), Color(0xff30b0c7), Color(0xff32ade6), Color(0xff007aff), Color(0xff5856d6), Color(0xffaf52de), Color(0xffff2d55), Color(0xffa2845e), Color(0xff8e8e93), Color(0xffaeaeb2), Color(0xffc7c7cc), Color(0xffd1d1d6), Color(0xffe5e5ea), Color(0xfff2f2f7))''',
+          'brightness: light'
+        ],
+      );
     });
   });
 }

--- a/packages/cupertino_plus/test/theme/cupertino_plus_theme_data_test.dart
+++ b/packages/cupertino_plus/test/theme/cupertino_plus_theme_data_test.dart
@@ -72,5 +72,78 @@ void main() {
         ],
       );
     });
+
+    testWidgets('CupertinoPlusTheme is null', (tester) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return Container();
+            },
+          ),
+        ),
+      );
+
+      expect(
+          () => CupertinoPlusTheme.of(capturedContext), throwsAssertionError);
+    });
+
+    testWidgets('StreamFeedTheme updateShouldNotify', (tester) async {
+      TestCupertinoPlusTheme? result;
+      final builder = Builder(
+        builder: (context) {
+          result = context
+              .dependOnInheritedWidgetOfExactType<TestCupertinoPlusTheme>();
+          return Container();
+        },
+      );
+
+      final first = TestCupertinoPlusTheme(
+        shouldNotify: true,
+        data: CupertinoPlusThemeData.light(),
+        child: builder,
+      );
+
+      final second = TestCupertinoPlusTheme(
+        shouldNotify: false,
+        data: CupertinoPlusThemeData.light(),
+        child: builder,
+      );
+
+      final third = TestCupertinoPlusTheme(
+        shouldNotify: true,
+        data: CupertinoPlusThemeData.light(),
+        child: builder,
+      );
+
+      await tester.pumpWidget(first);
+      expect(result, equals(first));
+
+      await tester.pumpWidget(second);
+      expect(result, equals(first));
+
+      await tester.pumpWidget(third);
+      expect(result, equals(third));
+    });
   });
+}
+
+class TestCupertinoPlusTheme extends CupertinoPlusTheme {
+  const TestCupertinoPlusTheme({
+    Key? key,
+    required CupertinoPlusThemeData data,
+    required Widget child,
+    required this.shouldNotify,
+  }) : super(key: key, data: data, child: child);
+
+  // ignore: diagnostic_describe_all_properties
+  final bool shouldNotify;
+
+  @override
+  bool updateShouldNotify(covariant CupertinoPlusTheme oldWidget) {
+    super.updateShouldNotify(oldWidget);
+    return shouldNotify;
+  }
 }


### PR DESCRIPTION
This PR makes a number of changes to the way theming is handled for `cupertino_plus`:
* Overhaul `CupertinoPlusTheme` widget
  * Now takes a single `CupertinoPlusThemeData` argument
  * Removes the `maybeOf` function
* Overhaul `CupertinoPlusThemeData` class
  * Now uses factory constructors
  * Adds `Brightness` property
  * Adds `debugFillProperties`
* Removes unnecessary icons constructor
* Adds 100% test coverage for all theme-related classes

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [X] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
